### PR TITLE
Quick fix for Boost 1.7.0; added compile and usage instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,33 @@
 !CMakeLists.txt
 doc/*
 !doc/Doxyfile
-test/
+tests/
 notes/
 build*/
 *.json
 *.a
 *.so
 tags
+keys
+### CMake ###
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+### CMake Patch ###
+# External projects
+*-prefix/
+CMakeDoxyfile.in
+CMakeDoxygenDefaults.cmake
+demos/get_favorites
+demos/search
+networklib/NetworkLibraryConfig.cmake
+twitterlib/TwitterLibraryConfig.cmake

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # C++ Twitter API Library
+
 A work in progress library for access to Twitter's REST and Streaming APIs.
+
 ```c++
 #include <iostream>
 #include <twitterlib/twitterlib.hpp>
@@ -13,7 +15,7 @@ int main() {
     app.account = account;
 
     // REST API - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    // Returns JSON response from twitter.
+    // Returns JSON response from Twitter.
     std::cout << get_account_settings(app) << std::endl;
 
     // Update account's status.
@@ -37,9 +39,32 @@ int main() {
 }
 ```
 
+## Build / compile
+
+Use `cmake .` to generate the build environment.
+
+Once successful, run `make && make demos` to build the libraries and the demo apps.
+
+## Usage
+
+[Register](https://developer.twitter.com/en/apply/user.html) for a Twitter Developer Account.
+Create a new application via the [Twitter App Dashboard](https://developer.twitter.com/en/apps).
+Take a note of the consumer keys and account secrets on the "Keys and Tokens" tab for your app.
+
+Create a text file called "keys" containing your Twitter API consumer keys and secrets:
+
+```text
+consumer_key *KEY*
+consumer_token *TOKEN*
+user_token *USERTOKEN*
+token_secret *TOKENSECRET*
+```
+
+Run the demo apps.
+
 ### Library Dependencies
+
 * Boost ASIO >= 1.58
 * Boost Property Tree >= 1.58
-* OpenSSL
+* OpenSSL >= 1.1
 * zlib
-

--- a/networklib/src/stream.cpp
+++ b/networklib/src/stream.cpp
@@ -18,42 +18,49 @@
 #include <networklib/oauth/oauth.hpp>
 #include <networklib/response.hpp>
 
-namespace network {
+namespace network
+{
 
-Stream::Stream(const Request& request)
+Stream::Stream(const Request &request)
     : request_{request}, sock_stream_{std::make_unique<detail::Socket>()} {}
 
-Stream::~Stream() {}  // for unique_ptr<Socket>
+Stream::~Stream() {} // for unique_ptr<Socket>
 
-void Stream::register_function(Callback f1, Condition f2) {
+void Stream::register_function(Callback f1, Condition f2)
+{
     callbacks_mutex_.lock();
     callbacks_.push_back(std::make_pair(f1, f2));
     callbacks_mutex_.unlock();
 }
 
 // Builds the request and calls asio::write()
-void Stream::open() {
+void Stream::open()
+{
     if (sock_stream_->socket_ptr != nullptr &&
-        sock_stream_->socket_ptr->lowest_layer().is_open()) {
+        sock_stream_->socket_ptr->lowest_layer().is_open())
+    {
         return;
     }
     sock_stream_->socket_ptr = detail::make_connection(request_);
     boost::asio::async_write(
         *(sock_stream_->socket_ptr), boost::asio::buffer(std::string(request_)),
-        [this](const boost::system::error_code& ec, std::size_t bytes) {
+        [this](const boost::system::error_code &ec, std::size_t bytes) {
             this->dispatch(ec, bytes);
         });
 }
 
 // Disconnects from the streaming API.
-void Stream::close() {
-    if (sock_stream_->socket_ptr == nullptr) {
+void Stream::close()
+{
+    if (sock_stream_->socket_ptr == nullptr)
+    {
         return;
     }
     boost::system::error_code ec;
     sock_stream_->socket_ptr->lowest_layer().shutdown(
         boost::asio::ip::tcp::socket::shutdown_both, ec);
-    if (ec != boost::system::errc::success) {
+    if (ec != boost::system::errc::success)
+    {
         throw boost::system::system_error{ec};
     }
     sock_stream_->socket_ptr->lowest_layer().close();
@@ -61,9 +68,11 @@ void Stream::close() {
 
 // Reads from the socket, creates Response objects and sends them to each
 // callback. Checks for reconnect_ on beginning of every iteration.
-void Stream::dispatch(const boost::system::error_code& ec,
-                      std::size_t bytes_transferred) {
-    if (ec != boost::system::errc::success) {
+void Stream::dispatch(const boost::system::error_code &ec,
+                      std::size_t bytes_transferred)
+{
+    if (ec != boost::system::errc::success)
+    {
         throw boost::system::system_error{ec};
     }
     reconnect_mtx_.lock();
@@ -75,18 +84,22 @@ void Stream::dispatch(const boost::system::error_code& ec,
 
     detail::Headers header(*sock_stream_->socket_ptr, buffer_read);
 
-    if (header.get("transfer-encoding") != "chunked") {
+    if (header.get("transfer-encoding") != "chunked")
+    {
         throw std::runtime_error("Stream transfer encoding is not chunked.");
     }
 
     std::string message_str;
     // TODO: add support for keep alive newlines
-    while (!reconnect_) {
+    while (!reconnect_)
+    {
         std::size_t pos{0};
         boost::asio::deadline_timer timer{
-            sock_stream_->socket_ptr->get_io_service(),
+            ((boost::asio::io_context &)(sock_stream_->socket_ptr)->get_executor().context()),
+            //                ->get_io_service(),
             boost::posix_time::seconds(90)};
-        while ((pos = message_str.find("\r\n")) == std::string::npos) {
+        while ((pos = message_str.find("\r\n")) == std::string::npos)
+        {
             timer.async_wait(
                 std::bind(&Stream::timer_expired, this, std::placeholders::_1));
             message_str.append(
@@ -94,10 +107,13 @@ void Stream::dispatch(const boost::system::error_code& ec,
             timer.cancel();
         }
         auto response = message_str.substr(0, pos);
-        if (response.size() > 1) {
+        if (response.size() > 1)
+        {
             this->send_response(Response{response});
             message_str.erase(0, pos + 2);
-        } else {
+        }
+        else
+        {
             message_str.clear();
         }
     }
@@ -105,30 +121,37 @@ void Stream::dispatch(const boost::system::error_code& ec,
     this->reconnect();
 }
 
-void Stream::reconnect() {
+void Stream::reconnect()
+{
     this->close();
     this->open();
 }
 
-void Stream::set_request(const Request& r) {
+void Stream::set_request(const Request &r)
+{
     request_ = r;
 }
 
-void Stream::timer_expired(const boost::system::error_code& ec) {
-    if (ec != boost::system::errc::success) {
+void Stream::timer_expired(const boost::system::error_code &ec)
+{
+    if (ec != boost::system::errc::success)
+    {
         throw boost::system::system_error{ec};
     }
     this->reconnect();
 }
 
-void Stream::send_response(const Response& response) {
+void Stream::send_response(const Response &response)
+{
     callbacks_mutex_.lock();
-    for (auto& pair : callbacks_) {
-        if (pair.second(response)) {
+    for (auto &pair : callbacks_)
+    {
+        if (pair.second(response))
+        {
             pair.first(response);
         }
     }
     callbacks_mutex_.unlock();
 }
 
-}  // namespace network
+} // namespace network


### PR DESCRIPTION
I found that this wouldn't compile with Boost 1.7 (I've got Boost installed via homebrew on macOS Catalina) - `basic_stream_socket::get_io_service()` was deprecated and removed. I made a quick patch to the network code to fix that, and added some basic compile and usage docs.

I also found that at cmake time, I had to force the use of OpenSSL 1.1 (I have both OpenSSL 1.0.x and 1.1 installed, for reasons)

Hope this helps! Nice work, by the way 👍 